### PR TITLE
fix: enable isort and balck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,11 @@ repos:
       exclude: docs/
       args:
       - --select=D101,D102,D103
-# - repo: https://github.com/timothycrosley/isort
-#   rev: 5.8.0
-#   hooks:
-#     - id: isort
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.8.0
+  hooks:
+   - id: isort
+     args: ["--profile", "black"]
 - repo: https://github.com/ambv/black
   rev: 20.8b1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
-- repo: https://github.com/terrencepreilly/darglint
-  rev: v1.5.8
-  hooks:
-  - id: darglint
-    files: pqlite/
-    exclude: docs/
-    args:
-    - --message-template={path}:{line} {msg_id} {msg}
-    - -s=sphinx
-    - -z=full
-    - -v=2
-- repo: https://github.com/pycqa/pydocstyle
-  rev: 5.1.1  # pick a git hash / tag to point to
-  hooks:
-  -   id: pydocstyle
-      files: pqlite/
-      exclude: docs/
-      args:
-      - --select=D101,D102,D103
+#- repo: https://github.com/terrencepreilly/darglint
+#  rev: v1.5.8
+#  hooks:
+#  - id: darglint
+#    files: pqlite/
+#    exclude: docs/
+#    args:
+#    - --message-template={path}:{line} {msg_id} {msg}
+#    - -s=sphinx
+#    - -z=full
+#    - -v=2
+#- repo: https://github.com/pycqa/pydocstyle
+#  rev: 5.1.1  # pick a git hash / tag to point to
+#  hooks:
+#  -   id: pydocstyle
+#      files: pqlite/
+#      exclude: docs/
+#      args:
+#      - --select=D101,D102,D103
 - repo: https://github.com/timothycrosley/isort
   rev: 5.8.0
   hooks:

--- a/bindings/pq_bindings.pyx
+++ b/bindings/pq_bindings.pyx
@@ -1,11 +1,19 @@
 # distutils: language = c++
 
 import numpy as np
-cimport cython
-from libcpp.vector cimport vector
 
-from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
-                          int8_t, int16_t, int32_t, int64_t)
+cimport cython
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+)
+from libcpp.vector cimport vector
 
 ctypedef fused any_int:
     uint8_t

--- a/examples/bench_insert_docarraymemmap_vs_pqlite.py
+++ b/examples/bench_insert_docarraymemmap_vs_pqlite.py
@@ -1,11 +1,13 @@
-import numpy as np
-
-from jina import Document, DocumentArrayMemmap, DocumentArray
-from sklearn.datasets import make_blobs
-from pqlite import PQLite
-import time
 import os
 import shutil
+import time
+
+import numpy as np
+from jina import Document, DocumentArray, DocumentArrayMemmap
+from sklearn.datasets import make_blobs
+
+from pqlite import PQLite
+
 
 def create_data_online(n_examples, D, batch_size):
     np.random.seed(123)
@@ -24,12 +26,14 @@ def create_data_online(n_examples, D, batch_size):
         )
         yield DocumentArray([Document(embedding=x) for x in Xtr_batch])
 
+
 def clean_workspace():
     if os.path.exists('./pqlite_storage'):
         shutil.rmtree('./pqlite_storage')
 
     if os.path.exists('./memmap'):
         shutil.rmtree('./memmap')
+
 
 def insert_docarraymemmmap(n_examples, n_features, batch_size=10_000):
 
@@ -46,24 +50,26 @@ def insert_docarraymemmmap(n_examples, n_features, batch_size=10_000):
     print(f'\n\ntotal time docarraymemmap={total_time} seconds\n\n')
     return total_time
 
+
 def insert_pqlite(n_examples, n_features, batch_size=100_000):
 
     da_generator = create_data_online(n_examples, n_features, batch_size)
     clean_workspace()
-    pqlite = PQLite(dim=n_features, data_path= 'pqlite_storage')
+    pqlite = PQLite(dim=n_features, data_path='pqlite_storage')
 
     total_time = 0
     for da in da_generator:
         t0 = time.time()
-        #embeddings = da.embeddings
-        #cell_ids = [0]*len(embeddings)
-        #pqlite.insert(embeddings, cell_ids, da)
+        # embeddings = da.embeddings
+        # cell_ids = [0]*len(embeddings)
+        # pqlite.insert(embeddings, cell_ids, da)
         pqlite.doc_store(0).insert(da)
         total_time += time.time() - t0
 
     total_time = round(total_time, 2)
     print(f'\n\ntotal time pqlite={total_time} seconds\n\n')
     return total_time
+
 
 n_examples = 1_000_000
 n_features = 512

--- a/examples/hnsw_benchmark.py
+++ b/examples/hnsw_benchmark.py
@@ -2,14 +2,14 @@ import time
 from datetime import date
 
 import numpy as np
-from pqlite import PQLite
-
+import pandas as pd
 from jina import Document, DocumentArray
 from jina.math.distance import cdist
 from jina.math.helper import top_k as _top_k
-import pandas as pd
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
+
+from pqlite import PQLite
 
 
 def _precision(predicted, relevant, eval_at):

--- a/examples/pq_benchmark.py
+++ b/examples/pq_benchmark.py
@@ -2,14 +2,14 @@ import time
 from datetime import date
 
 import numpy as np
-from pqlite import PQLite
-
+import pandas as pd
 from jina import Document, DocumentArray
 from jina.math.distance import cdist
 from jina.math.helper import top_k as _top_k
-import pandas as pd
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
+
+from pqlite import PQLite
 
 
 def _precision(predicted, relevant, eval_at):

--- a/examples/pqlite_vs_simpleindexer.py
+++ b/examples/pqlite_vs_simpleindexer.py
@@ -1,17 +1,16 @@
-import time
 import os
 import shutil
-
-from jina import Flow
-from jina import Document, DocumentArray
-from jina.math.distance import cdist
-from jina.math.helper import top_k as _top_k
-from executor.executor_pqlite import PQLiteIndexer
+import time
 
 import numpy as np
 import pandas as pd
+from jina import Document, DocumentArray, Flow
+from jina.math.distance import cdist
+from jina.math.helper import top_k as _top_k
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
+
+from executor.executor_pqlite import PQLiteIndexer
 
 Nq = 1
 D = 128

--- a/executor/executor.py
+++ b/executor/executor.py
@@ -1,6 +1,8 @@
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
+
 from jina import Document, DocumentArray, Executor, requests
 from jina.logging.logger import JinaLogger
+
 import pqlite
 
 

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -1,9 +1,8 @@
-from jina import Document, DocumentArray, Flow, Executor
-
-from ..executor import PQLiteIndexer
 import numpy as np
 import pytest
+from jina import Document, DocumentArray, Executor, Flow
 
+from ..executor import PQLiteIndexer
 
 N = 1000  # number of data points
 Nt = 2000

--- a/pqlite/core/codec/pq.py
+++ b/pqlite/core/codec/pq.py
@@ -10,7 +10,6 @@ from .base import BaseCodec
 # from pqlite.pq_bind import precompute_adc_table, dist_pqcodes_to_codebooks
 
 
-
 class PQCodec(BaseCodec):
     """Implementation of Product Quantization (PQ) [Jegou11]_.
 

--- a/pqlite/index.py
+++ b/pqlite/index.py
@@ -214,43 +214,43 @@ class PQLite(CellContainer):
         """
         query_np = docs.embeddings
 
-        match_dists, match_docs = self._search_documents(query_np,
-                                                         filter,
-                                                         limit,
-                                                         include_metadata)
+        match_dists, match_docs = self._search_documents(
+            query_np, filter, limit, include_metadata
+        )
 
         for doc, matches in zip(docs, match_docs):
             doc.matches = matches
 
-    def _search_documents(self,
-                query_np,
-                filter: Dict = {},
-                limit: int = 10,
-                include_metadata: bool = True):
+    def _search_documents(
+        self,
+        query_np,
+        filter: Dict = {},
+        limit: int = 10,
+        include_metadata: bool = True,
+    ):
 
         cells = self._cell_selection(query_np, limit)
         where_clause, where_params = Filter(filter).parse_where_clause()
 
         match_dists, match_docs = self.search_cells(
-                query=query_np,
-                cells=cells,
-                where_clause=where_clause,
-                where_params=where_params,
-                limit=limit,
-                include_metadata=include_metadata,
+            query=query_np,
+            cells=cells,
+            where_clause=where_clause,
+            where_params=where_params,
+            limit=limit,
+            include_metadata=include_metadata,
         )
         return match_dists, match_docs
 
-
-    def _cell_selection(self,
-                        query_np,
-                        limit):
+    def _cell_selection(self, query_np, limit):
 
         n_data, _ = self._sanity_check(query_np)
         assert 0 < limit <= 1024
 
         if self.vq_codec:
-            dists = cdist(query_np, self.vq_codec.codebook, metric=self.metric.name.lower())
+            dists = cdist(
+                query_np, self.vq_codec.codebook, metric=self.metric.name.lower()
+            )
             dists, cells = top_k(dists, k=self.n_probe)
         else:
             cells = np.zeros((n_data, 1), dtype=np.int64)
@@ -288,16 +288,10 @@ class PQLite(CellContainer):
         :param include_metadata: whether to return document metadata in response.
         """
 
-        dists, doc_ids = self._search_numpy(query_np,
-                                            filter,
-                                            limit)
+        dists, doc_ids = self._search_numpy(query_np, filter, limit)
         return dists, doc_ids
 
-
-    def _search_numpy(self,
-                      query_np,
-                      filter: Dict = {},
-                      limit: int = 10):
+    def _search_numpy(self, query_np, filter: Dict = {}, limit: int = 10):
         """Search approximate nearest vectors in different cells, returns distances and ids
 
         :param query_np: matrix containing query vectors as rows
@@ -308,14 +302,13 @@ class PQLite(CellContainer):
         where_clause, where_params = Filter(filter).parse_where_clause()
 
         dists, ids = self._search_cells(
-                query=query_np,
-                cells=cells,
-                where_clause=where_clause,
-                where_params=where_params,
-                limit=limit,
-            )
+            query=query_np,
+            cells=cells,
+            where_clause=where_clause,
+            where_params=where_params,
+            limit=limit,
+        )
         return dists, ids
-
 
     def delete(self, docs: Union[DocumentArray, List[str]]):
         """Delete entries from the index by id

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 import os
 import sys
+from distutils.sysconfig import get_python_inc
+
 import numpy as np
 import pybind11
-
 import setuptools
-from setuptools.command.build_ext import build_ext
-from setuptools import setup, find_packages, Extension
-
 from Cython.Build import cythonize
-from distutils.sysconfig import get_python_inc
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext
 
 if sys.version_info >= (3, 10, 0) or sys.version_info < (3, 7, 0):
     raise OSError(f'PQlite requires Python 3.7/3.8/3.9, but yours is {sys.version}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
+import numpy as np
 import pytest
 from jina import Document, DocumentArray
-import numpy as np
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -52,6 +52,7 @@ def pqlite_with_data(tmpdir):
     index.index(docs)
     return index
 
+
 @pytest.fixture
 def heterogenenous_da(tmpdir):
     prices = [10.0, 25.0, 50.0, 100.0]
@@ -155,9 +156,9 @@ def test_query_search_filter_float_type(pqlite_with_heterogeneous_tags, operator
 
 
 @pytest.mark.parametrize('operator', list(numeric_operators.keys()))
-def test_query_search_numpy_filter_float_type(pqlite_with_heterogeneous_tags,
-                                              heterogenenous_da,
-                                              operator):
+def test_query_search_numpy_filter_float_type(
+    pqlite_with_heterogeneous_tags, heterogenenous_da, operator
+):
 
     X = np.random.random((Nq, D)).astype(np.float32)
     query_np = np.array([X[i] for i in range(Nq)])
@@ -171,7 +172,9 @@ def test_query_search_numpy_filter_float_type(pqlite_with_heterogeneous_tags,
         for doc_ids_query_k in doc_ids:
             assert all(
                 [
-                    numeric_operators[operator](da[int(doc_id)].tags['price'], threshold)
+                    numeric_operators[operator](
+                        da[int(doc_id)].tags['price'], threshold
+                    )
                     for doc_id in doc_ids_query_k
                 ]
             )
@@ -197,9 +200,9 @@ def test_search_filter_str(pqlite_with_heterogeneous_tags, operator):
 
 
 @pytest.mark.parametrize('operator', list(categorical_operators.keys()))
-def test_search_numpy_filter_str(pqlite_with_heterogeneous_tags,
-                                 heterogenenous_da,
-                                 operator):
+def test_search_numpy_filter_str(
+    pqlite_with_heterogeneous_tags, heterogenenous_da, operator
+):
 
     X = np.random.random((Nq, D)).astype(np.float32)
     query_np = np.array([X[i] for i in range(Nq)])
@@ -213,8 +216,9 @@ def test_search_numpy_filter_str(pqlite_with_heterogeneous_tags,
         for doc_ids_query_k in doc_ids:
             assert all(
                 [
-                    numeric_operators[operator](da[int(doc_id)].tags['category'], category)
+                    numeric_operators[operator](
+                        da[int(doc_id)].tags['category'], category
+                    )
                     for doc_id in doc_ids_query_k
                 ]
             )
-

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,9 +1,11 @@
-import pytest
-import random
-import numpy as np
-from jina import Document, DocumentArray
-from pqlite import PQLite
 import operator
+import random
+
+import numpy as np
+import pytest
+from jina import Document, DocumentArray
+
+from pqlite import PQLite
 
 N = 1000  # number of data points
 Nq = 5

--- a/tests/test_pq_bind.py
+++ b/tests/test_pq_bind.py
@@ -1,10 +1,8 @@
-import pytest
 import numpy as np
+import pytest
+
 from pqlite.core.codec.pq import PQCodec
-from pqlite.pq_bind import (
-    precompute_adc_table,
-    dist_pqcodes_to_codebooks,
-)
+from pqlite.pq_bind import dist_pqcodes_to_codebooks, precompute_adc_table
 
 n_examples = 2000
 n_features = 128

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,5 +1,6 @@
 import pytest
 from jina import Document, DocumentArray
+
 from pqlite.storage.table import CellTable, MetaTable
 
 


### PR DESCRIPTION
With PR, the linting and formating can be done via 
```
$ pre-commit run --all
```

How to enable `pre-commit` ?
```
$ pre-commit install
```